### PR TITLE
Fix statting the output file for skipped runs

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -32,16 +32,18 @@ def is_subset_in(d, lst):
             return True
     return False
 
-def map_loop_results(results, attr):
-    """ Take a results attribute from a registered task, and convert it into a dict of item->attr
-        If the loop item is a dict, it is c"""
+def map_loop_results(results, attr, default=None):
+    """ Take a results attribute from a looped registered task, and convert it into a dict of item->attr
+        If the loop item is a dict, it is converted into a json string to make it usable as a dict key.
+        If 'attr' is not presnet in the task (e.g. because it's been skipped in a loop) then use 'default' if provided else error.
+    """
     output = {}
     for res in results:
         if isinstance(res['item'], dict):
             key = json.dumps(res['item'])
         else:
             key = res['item']
-        output[key] = res[attr]
+        output[key] = res.get(attr, default)
     return output
 
 class FilterModule(object):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,6 @@
+- debug:
+    msg: "Will produce at most {{ smatrix_dimensions | dict2product | length }} runs"
+  tags: always
 - import_tasks: template.yml
   tags: template
 - import_tasks: submit.yml

--- a/tasks/submit.yml
+++ b/tasks/submit.yml
@@ -8,7 +8,7 @@
 
 - name: Convert stat output into mapping
   set_fact:
-    _stat_output_paths: "{{ _stat_output_path.results | map_loop_results('stat') }}"
+    _stat_output_paths: "{{ _stat_output_path.results | map_loop_results('stat', {'exists':false} ) }}"
 
 - name: Submit jobs
   command:


### PR DESCRIPTION
If runs are skipped using `smatrix_exclude`, then the stat for that result doesn't exist. This PR fixes that so that skipped runs work.